### PR TITLE
Add support for 1.21

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R1/pom.xml
+++ b/1_21_R1/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>signgui-1_15_R1</artifactId>
+    <artifactId>signgui-1_21_R1</artifactId>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.15-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -29,4 +29,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/1_21_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R1.java
+++ b/1_21_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R1.java
@@ -1,0 +1,165 @@
+package de.rapha149.signgui.version;
+
+import de.rapha149.signgui.SignEditor;
+import de.rapha149.signgui.SignGUIChannelHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import net.minecraft.core.BlockPosition;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.PacketPlayInUpdateSign;
+import net.minecraft.network.protocol.game.PacketPlayOutOpenSignEditor;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.server.network.PlayerConnection;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import net.minecraft.world.item.EnumColor;
+import net.minecraft.world.level.World;
+import net.minecraft.world.level.block.entity.SignText;
+import net.minecraft.world.level.block.entity.TileEntitySign;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_21_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+public class Wrapper1_21_R1 implements VersionWrapper {
+
+    private final Field NETWORK_MANAGER_FIELD;
+
+    {
+        Field networkManagerField = null;
+        for (Field field : ServerCommonPacketListenerImpl.class.getDeclaredFields()) {
+            if (field.getType() == NetworkManager.class) {
+                field.setAccessible(true);
+                networkManagerField = field;
+                break;
+            }
+        }
+
+        NETWORK_MANAGER_FIELD = networkManagerField;
+    }
+
+    @Override
+    public Material getDefaultType() {
+        return Material.OAK_SIGN;
+    }
+
+    @Override
+    public List<Material> getSignTypes() {
+        return Arrays.asList(Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN, Material.JUNGLE_SIGN,
+                Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.CRIMSON_SIGN, Material.WARPED_SIGN,
+                Material.CHERRY_SIGN, Material.MANGROVE_SIGN, Material.BAMBOO_SIGN
+        );
+    }
+
+    @Override
+    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+        EntityPlayer p = ((CraftPlayer) player).getHandle();
+        PlayerConnection conn = p.c;
+
+        if (NETWORK_MANAGER_FIELD == null)
+            throw new IllegalStateException("Unable to find NetworkManager field in PlayerConnection class.");
+        if (!NETWORK_MANAGER_FIELD.canAccess(conn)) {
+            NETWORK_MANAGER_FIELD.setAccessible(true);
+            if (!NETWORK_MANAGER_FIELD.canAccess(conn))
+                throw new IllegalStateException("Unable to access NetworkManager field in PlayerConnection class.");
+        }
+
+        Location loc = signLoc != null ? signLoc : getDefaultLocation(player);
+        BlockPosition pos = new BlockPosition(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+
+        TileEntitySign sign = new TileEntitySign(pos, null);
+        SignText signText = sign.a(true) // flag = front/back of sign
+                .a(EnumColor.valueOf(color.toString()));
+        for (int i = 0; i < lines.length; i++)
+            signText = signText.a(i, IChatBaseComponent.a(lines[i]));
+        sign.a(signText, true);
+
+        boolean schedule = false;
+        NetworkManager manager = (NetworkManager) NETWORK_MANAGER_FIELD.get(conn);
+        ChannelPipeline pipeline = manager.n.pipeline();
+        if (pipeline.names().contains("SignGUI")) {
+            ChannelHandler handler = pipeline.get("SignGUI");
+            if (handler instanceof SignGUIChannelHandler<?> signGUIHandler) {
+                signGUIHandler.close();
+                schedule = signGUIHandler.getBlockPosition().equals(pos);
+            }
+
+            if (pipeline.names().contains("SignGUI"))
+                pipeline.remove("SignGUI");
+        }
+
+        Runnable runnable = () -> {
+            player.sendBlockChange(loc, type.createBlockData());
+            sign.a(p.cN());
+            conn.b(sign.l());
+            sign.a((World) null);
+            conn.b(new PacketPlayOutOpenSignEditor(pos, true)); // flag = front/back of sign
+
+            SignEditor signEditor = new SignEditor(sign, loc, pos, pipeline);
+            pipeline.addAfter("decoder", "SignGUI", new SignGUIChannelHandler<Packet<?>>() {
+
+                @Override
+                public Object getBlockPosition() {
+                    return pos;
+                }
+
+                @Override
+                public void close() {
+                    closeSignEditor(player, signEditor);
+                }
+
+                @Override
+                protected void decode(ChannelHandlerContext chc, Packet<?> packet, List<Object> out) {
+                    try {
+                        if (packet instanceof PacketPlayInUpdateSign updateSign) {
+                            if (updateSign.b().equals(pos))
+                                onFinish.accept(signEditor, updateSign.f());
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+
+                    out.add(packet);
+                }
+            });
+        };
+
+        if (schedule)
+            SCHEDULER.schedule(runnable, 200, TimeUnit.MILLISECONDS);
+        else
+            runnable.run();
+    }
+
+    @Override
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+        TileEntitySign sign = (TileEntitySign) signEditor.getSign();
+
+        SignText newSignText = sign.a(true);
+        for (int i = 0; i < lines.length; i++)
+            newSignText = newSignText.a(i, IChatBaseComponent.a(lines[i]));
+        sign.a(newSignText, true);
+
+        EntityPlayer p = ((CraftPlayer) player).getHandle();
+        PlayerConnection conn = p.c;
+        sign.a(p.cN());
+        conn.b(sign.l());
+        sign.a((World) null);
+        conn.b(new PacketPlayOutOpenSignEditor((BlockPosition) signEditor.getBlockPosition(), true));
+    }
+
+    @Override
+    public void closeSignEditor(Player player, SignEditor signEditor) {
+        Location loc = signEditor.getLocation();
+        signEditor.getPipeline().remove("SignGUI");
+        player.sendBlockChange(loc, loc.getBlock().getBlockData());
+    }
+}

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SignGUI [![Build](https://github.com/Rapha149/SignGUI/actions/workflows/build.yml/badge.svg)](https://github.com/Rapha149/SignGUI/actions/workflows/build.yml) [![Maven Central](https://img.shields.io/maven-central/v/de.rapha149.signgui/signgui?label=Maven%20Central)](https://central.sonatype.com/artifact/de.rapha149.signgui/signgui) [![Javadoc](https://javadoc.io/badge2/de.rapha149.signgui/signgui/Javadoc.svg)](https://javadoc.io/doc/de.rapha149.signgui/signgui) 
 An api to get input text via a sign in Minecraft.  
-The api supports the Minecraft versions from `1.8` to `1.20.6`.
+The api supports the Minecraft versions from `1.8` to `1.21`.
 
 ## Integration
 
@@ -9,7 +9,7 @@ Maven dependency:
 <dependency>
     <groupId>de.rapha149.signgui</groupId>
     <artifactId>signgui</artifactId>
-    <version>2.3.3</version>
+    <version>2.3.4</version>
 </dependency>
 ```
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
 
     <artifactId>signgui</artifactId>
@@ -198,6 +198,12 @@
         <dependency>
             <groupId>de.rapha149.signgui</groupId>
             <artifactId>signgui-1_20_R4</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.signgui</groupId>
+            <artifactId>signgui-1_21_R1</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>de.rapha149.signgui</groupId>
     <artifactId>signgui-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.3</version>
+    <version>2.3.4</version>
 
     <modules>
         <module>api</module>
@@ -37,6 +37,7 @@
         <module>1_20_R2</module>
         <module>1_20_R3</module>
         <module>1_20_R4</module>
+        <module>1_21_R1</module>
     </modules>
 
     <properties>

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
     </parent>
 
     <artifactId>signgui-wrapper</artifactId>


### PR DESCRIPTION
This PR contains code to support `1.21` servers.

Test Build Environment:
- JRE 21
- Successfully built and tested with a CommandPrompter upcoming update.

Notes for review:
- The majority of the code is similar to `1_20_R4`.
- `World` accessor for `EntityPlayer` changed from `dP()` -> `cN()`.
- Version bumped to `2.3.4` for all modules.
- Updated `README.md`
