### PR TITLE
Mojang-mapped plugins support and adventure lines support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/
 dependency-reduced-pom.xml
 .mvn/
 .flattened-pom.xml
+.paper-nms/

--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_10_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_10_R1.java
+++ b/1_10_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_10_R1.java
@@ -31,7 +31,7 @@ public class Wrapper1_10_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_10_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_10_R1.java
+++ b/1_10_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_10_R1.java
@@ -98,7 +98,7 @@ public class Wrapper1_10_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.lines[i] = new ChatComponentText(lines[i] != null ? lines[i] : "");

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_11_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_11_R1.java
+++ b/1_11_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_11_R1.java
@@ -98,7 +98,7 @@ public class Wrapper1_11_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.lines[i] = new ChatComponentText(lines[i] != null ? lines[i] : "");

--- a/1_11_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_11_R1.java
+++ b/1_11_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_11_R1.java
@@ -31,7 +31,7 @@ public class Wrapper1_11_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_12_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_12_R1.java
+++ b/1_12_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_12_R1.java
@@ -31,7 +31,7 @@ public class Wrapper1_12_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_12_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_12_R1.java
+++ b/1_12_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_12_R1.java
@@ -98,7 +98,7 @@ public class Wrapper1_12_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.lines[i] = new ChatComponentText(lines[i] != null ? lines[i] : "");

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_13_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_13_R1.java
+++ b/1_13_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_13_R1.java
@@ -97,7 +97,7 @@ public class Wrapper1_13_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.lines[i] = new ChatComponentText(lines[i] != null ? lines[i] : "");

--- a/1_13_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_13_R1.java
+++ b/1_13_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_13_R1.java
@@ -30,7 +30,7 @@ public class Wrapper1_13_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_13_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_13_R2.java
+++ b/1_13_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_13_R2.java
@@ -30,7 +30,7 @@ public class Wrapper1_13_R2 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_13_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_13_R2.java
+++ b/1_13_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_13_R2.java
@@ -97,7 +97,7 @@ public class Wrapper1_13_R2 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, new ChatComponentText(lines[i] != null ? lines[i] : ""));

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_14_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_14_R1.java
+++ b/1_14_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_14_R1.java
@@ -36,7 +36,7 @@ public class Wrapper1_14_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws NoSuchFieldException, IllegalAccessException {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws NoSuchFieldException, IllegalAccessException {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_14_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_14_R1.java
+++ b/1_14_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_14_R1.java
@@ -109,7 +109,7 @@ public class Wrapper1_14_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, new ChatComponentText(lines[i] != null ? lines[i] : ""));

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_15_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_15_R1.java
+++ b/1_15_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_15_R1.java
@@ -99,7 +99,7 @@ public class Wrapper1_15_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, new ChatComponentText(lines[i] != null ? lines[i] : ""));

--- a/1_15_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_15_R1.java
+++ b/1_15_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_15_R1.java
@@ -31,7 +31,7 @@ public class Wrapper1_15_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_16_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R1.java
+++ b/1_16_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R1.java
@@ -99,7 +99,7 @@ public class Wrapper1_16_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, new ChatComponentText(lines[i] != null ? lines[i] : ""));

--- a/1_16_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R1.java
+++ b/1_16_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R1.java
@@ -31,7 +31,7 @@ public class Wrapper1_16_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_16_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R2.java
+++ b/1_16_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R2.java
@@ -31,7 +31,7 @@ public class Wrapper1_16_R2 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_16_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R2.java
+++ b/1_16_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R2.java
@@ -99,7 +99,7 @@ public class Wrapper1_16_R2 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, new ChatComponentText(lines[i] != null ? lines[i] : ""));

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_16_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R3.java
+++ b/1_16_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R3.java
@@ -99,7 +99,7 @@ public class Wrapper1_16_R3 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, new ChatComponentText(lines[i] != null ? lines[i] : ""));

--- a/1_16_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R3.java
+++ b/1_16_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_16_R3.java
@@ -31,7 +31,7 @@ public class Wrapper1_16_R3 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_17_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_17_R1.java
+++ b/1_17_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_17_R1.java
@@ -104,7 +104,7 @@ public class Wrapper1_17_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, IChatBaseComponent.a(lines[i]));

--- a/1_17_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_17_R1.java
+++ b/1_17_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_17_R1.java
@@ -39,7 +39,7 @@ public class Wrapper1_17_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.b;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_18_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_18_R1.java
+++ b/1_18_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_18_R1.java
@@ -104,7 +104,7 @@ public class Wrapper1_18_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, IChatBaseComponent.a(lines[i]));

--- a/1_18_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_18_R1.java
+++ b/1_18_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_18_R1.java
@@ -39,7 +39,7 @@ public class Wrapper1_18_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.b;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_18_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_18_R2.java
+++ b/1_18_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_18_R2.java
@@ -104,7 +104,7 @@ public class Wrapper1_18_R2 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, IChatBaseComponent.a(lines[i]));

--- a/1_18_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_18_R2.java
+++ b/1_18_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_18_R2.java
@@ -39,7 +39,7 @@ public class Wrapper1_18_R2 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.b;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R1.java
+++ b/1_19_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R1.java
@@ -104,7 +104,7 @@ public class Wrapper1_19_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, IChatBaseComponent.a(lines[i]));

--- a/1_19_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R1.java
+++ b/1_19_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R1.java
@@ -39,7 +39,7 @@ public class Wrapper1_19_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.b;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R2.java
+++ b/1_19_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R2.java
@@ -39,7 +39,7 @@ public class Wrapper1_19_R2 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.b;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_19_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R2.java
+++ b/1_19_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R2.java
@@ -104,7 +104,7 @@ public class Wrapper1_19_R2 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, IChatBaseComponent.a(lines[i]));

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>signgui-parent</artifactId>
+        <version>2.4.0</version>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>signgui-parent</artifactId>
-        <version>2.4.0</version>
         <groupId>de.rapha149.signgui</groupId>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R3.java
+++ b/1_19_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R3.java
@@ -131,7 +131,7 @@ public class Wrapper1_19_R3 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.a(i, IChatBaseComponent.a(lines[i]));

--- a/1_19_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R3.java
+++ b/1_19_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_19_R3.java
@@ -56,7 +56,7 @@ public class Wrapper1_19_R3 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.b;
 

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R1.java
+++ b/1_20_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R1.java
@@ -59,7 +59,7 @@ public class Wrapper1_20_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.c;
 

--- a/1_20_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R1.java
+++ b/1_20_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R1.java
@@ -136,7 +136,7 @@ public class Wrapper1_20_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
 
         SignText newSignText = sign.a(true);

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R2.java
+++ b/1_20_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R2.java
@@ -60,7 +60,7 @@ public class Wrapper1_20_R2 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.c;
 

--- a/1_20_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R2.java
+++ b/1_20_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R2.java
@@ -137,7 +137,7 @@ public class Wrapper1_20_R2 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
 
         SignText newSignText = sign.a(true);

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R3.java
+++ b/1_20_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R3.java
@@ -15,7 +15,6 @@ import net.minecraft.server.level.EntityPlayer;
 import net.minecraft.server.network.PlayerConnection;
 import net.minecraft.server.network.ServerCommonPacketListenerImpl;
 import net.minecraft.world.item.EnumColor;
-import net.minecraft.world.level.block.entity.CrafterBlockEntity;
 import net.minecraft.world.level.block.entity.SignText;
 import net.minecraft.world.level.block.entity.TileEntitySign;
 import org.bukkit.DyeColor;
@@ -61,7 +60,7 @@ public class Wrapper1_20_R3 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.c;
 

--- a/1_20_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R3.java
+++ b/1_20_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R3.java
@@ -137,7 +137,7 @@ public class Wrapper1_20_R3 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
 
         SignText newSignText = sign.a(true);

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R4/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R4.java
+++ b/1_20_R4/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R4.java
@@ -140,7 +140,7 @@ public class Wrapper1_20_R4 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
 
         SignText newSignText = sign.a(true);

--- a/1_20_R4/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R4.java
+++ b/1_20_R4/src/main/java/de/rapha149/signgui/version/Wrapper1_20_R4.java
@@ -61,7 +61,7 @@ public class Wrapper1_20_R4 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.c;
 

--- a/1_21_R1/pom.xml
+++ b/1_21_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R1.java
+++ b/1_21_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R1.java
@@ -61,7 +61,7 @@ public class Wrapper1_21_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.c;
 

--- a/1_21_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R1.java
+++ b/1_21_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R1.java
@@ -140,7 +140,7 @@ public class Wrapper1_21_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
 
         SignText newSignText = sign.a(true);

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_8_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R1.java
+++ b/1_8_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R1.java
@@ -33,7 +33,7 @@ public class Wrapper1_8_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws NoSuchFieldException, IllegalAccessException {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws NoSuchFieldException, IllegalAccessException {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_8_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R1.java
+++ b/1_8_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R1.java
@@ -104,7 +104,7 @@ public class Wrapper1_8_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.lines[i] = new ChatComponentText(lines[i] != null ? lines[i] : "");

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_8_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R2.java
+++ b/1_8_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R2.java
@@ -31,7 +31,7 @@ public class Wrapper1_8_R2 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_8_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R2.java
+++ b/1_8_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R2.java
@@ -98,7 +98,7 @@ public class Wrapper1_8_R2 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.lines[i] = new ChatComponentText(lines[i] != null ? lines[i] : "");

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_8_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R3.java
+++ b/1_8_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R3.java
@@ -31,7 +31,7 @@ public class Wrapper1_8_R3 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_8_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R3.java
+++ b/1_8_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_8_R3.java
@@ -98,7 +98,7 @@ public class Wrapper1_8_R3 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.lines[i] = new ChatComponentText(lines[i] != null ? lines[i] : "");

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_9_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_9_R1.java
+++ b/1_9_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_9_R1.java
@@ -31,7 +31,7 @@ public class Wrapper1_9_R1 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_9_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_9_R1.java
+++ b/1_9_R1/src/main/java/de/rapha149/signgui/version/Wrapper1_9_R1.java
@@ -98,7 +98,7 @@ public class Wrapper1_9_R1 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.lines[i] = new ChatComponentText(lines[i] != null ? lines[i] : "");

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
+        <version>2.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_9_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_9_R2.java
+++ b/1_9_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_9_R2.java
@@ -31,7 +31,7 @@ public class Wrapper1_9_R2 implements VersionWrapper {
     }
 
     @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.playerConnection;
         Location loc = signLoc != null ? signLoc : getDefaultLocation(player);

--- a/1_9_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_9_R2.java
+++ b/1_9_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_9_R2.java
@@ -98,7 +98,7 @@ public class Wrapper1_9_R2 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         TileEntitySign sign = (TileEntitySign) signEditor.getSign();
         for (int i = 0; i < lines.length; i++)
             sign.lines[i] = new ChatComponentText(lines[i] != null ? lines[i] : "");

--- a/Mojang1_20_R4/pom.xml
+++ b/Mojang1_20_R4/pom.xml
@@ -16,6 +16,7 @@
     </properties>
 
     <dependencies>
+        <!-- plugins -> paper-nms -> init (https://github.com/Alvinn8/paper-nms-maven-plugin) -->
         <dependency>
             <groupId>ca.bkaw</groupId>
             <artifactId>paper-nms</artifactId>

--- a/Mojang1_20_R4/pom.xml
+++ b/Mojang1_20_R4/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>signgui-parent</artifactId>
+        <version>2.4.0</version>
+        <groupId>de.rapha149.signgui</groupId>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>signgui-1_20_R4-mojang</artifactId>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ca.bkaw</groupId>
+            <artifactId>paper-nms</artifactId>
+            <version>1.20.6-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.signgui</groupId>
+            <artifactId>signgui-wrapper</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bytecode.space</id>
+            <url>https://repo.bytecode.space/repository/maven-public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>ca.bkaw</groupId>
+                <artifactId>paper-nms-maven-plugin</artifactId>
+                <version>1.4.4</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/Mojang1_20_R4/src/main/java/de/rapha149/signgui/version/MojangWrapper1_20_R4.java
+++ b/Mojang1_20_R4/src/main/java/de/rapha149/signgui/version/MojangWrapper1_20_R4.java
@@ -1,0 +1,179 @@
+package de.rapha149.signgui.version;
+
+import de.rapha149.signgui.SignEditor;
+import de.rapha149.signgui.SignGUIChannelHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.papermc.paper.adventure.AdventureComponent;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.Connection;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundOpenSignEditorPacket;
+import net.minecraft.network.protocol.game.ServerboundSignUpdatePacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.level.block.entity.SignBlockEntity;
+import net.minecraft.world.level.block.entity.SignText;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+public class MojangWrapper1_20_R4 implements AdventureVersionWrapper {
+
+    @Override
+    public Material getDefaultType() {
+        return Material.OAK_SIGN;
+    }
+
+    @Override
+    public List<Material> getSignTypes() {
+        return Arrays.asList(Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN, Material.JUNGLE_SIGN,
+                Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.CRIMSON_SIGN, Material.WARPED_SIGN,
+                Material.CHERRY_SIGN, Material.MANGROVE_SIGN, Material.BAMBOO_SIGN
+        );
+    }
+
+    private net.kyori.adventure.text.Component[] adventureLines = null;
+
+    @Override
+    public void setAdventureLines(Object[] lines) {
+        var tmp = new net.kyori.adventure.text.Component[4];
+        for (int i = 0; i < lines.length; i++) {
+            var line = lines[i];
+            if (line instanceof net.kyori.adventure.text.Component comp) {
+                tmp[i] = comp;
+            } else if (line == null) {
+                tmp[i] = null;
+            } else {
+                throw new IllegalArgumentException("line at index "+i+" is not net.kyori.adventure.text.Component");
+            }
+        }
+        adventureLines = tmp;
+    }
+
+    private Component[] createLines(String[] textLines){
+        var ret = new Component[4];
+        if (adventureLines != null) {
+            for (int i = 0; i < adventureLines.length; i++) {
+                var comp = adventureLines[i];
+                if (comp == null) {
+                    ret[i] = Component.empty();
+                } else {
+                    ret[i] = new AdventureComponent(comp);
+                }
+            }
+        } else {
+            for (int i = 0; i < textLines.length; i++) {
+                var line = textLines[i];
+                ret[i] = Component.nullToEmpty(line);
+            }
+        }
+        return ret;
+    }
+
+    @Override
+    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+        ServerPlayer p = ((CraftPlayer) player).getHandle();
+        ServerGamePacketListenerImpl conn = p.connection;
+
+        Location loc = signLoc != null ? signLoc : getDefaultLocation(player);
+        BlockPos pos = new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+
+        SignBlockEntity sign = new SignBlockEntity(pos, null);
+        SignText signText = sign.getText(true) // flag = front/back of sign
+                .setColor(net.minecraft.world.item.DyeColor.valueOf(color.toString()));
+        var linesToSet = createLines(lines);
+        for (int i = 0; i < linesToSet.length; i++)
+            signText = signText.setMessage(i, linesToSet[i]);
+        sign.setText(signText, true);
+
+        boolean schedule = false;
+        Connection manager = conn.connection;
+        ChannelPipeline pipeline = manager.channel.pipeline();
+        if (pipeline.names().contains("SignGUI")) {
+            ChannelHandler handler = pipeline.get("SignGUI");
+            if (handler instanceof SignGUIChannelHandler<?> signGUIHandler) {
+                signGUIHandler.close();
+                schedule = signGUIHandler.getBlockPosition().equals(pos);
+            }
+
+            if (pipeline.names().contains("SignGUI"))
+                pipeline.remove("SignGUI");
+        }
+
+        Runnable runnable = () -> {
+            player.sendBlockChange(loc, type.createBlockData());
+            sign.setLevel(p.level());
+            conn.send(sign.getUpdatePacket());
+            sign.setLevel(null);
+            conn.send(new ClientboundOpenSignEditorPacket(pos, true)); // flag = front/back of sign
+
+            SignEditor signEditor = new SignEditor(sign, loc, pos, pipeline);
+            pipeline.addAfter("decoder", "SignGUI", new SignGUIChannelHandler<Packet<?>>() {
+
+                @Override
+                public Object getBlockPosition() {
+                    return pos;
+                }
+
+                @Override
+                public void close() {
+                    closeSignEditor(player, signEditor);
+                }
+
+                @Override
+                protected void decode(ChannelHandlerContext chc, Packet<?> packet, List<Object> out) {
+                    try {
+                        if (packet instanceof ServerboundSignUpdatePacket updateSign) {
+                            if (updateSign.getPos().equals(pos))
+                                onFinish.accept(signEditor, updateSign.getLines());
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+
+                    out.add(packet);
+                }
+            });
+        };
+
+        if (schedule)
+            SCHEDULER.schedule(runnable, 200, TimeUnit.MILLISECONDS);
+        else
+            runnable.run();
+    }
+
+    @Override
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+        SignBlockEntity sign = (SignBlockEntity)signEditor.getSign();
+
+        SignText newSignText = sign.getText(true);
+        for(int i = 0; i < lines.length; ++i) {
+            newSignText = newSignText.setMessage(i, Component.nullToEmpty(lines[i]));
+        }
+        sign.setText(newSignText, true);
+
+        ServerPlayer p = ((CraftPlayer)player).getHandle();
+        ServerGamePacketListenerImpl conn = p.connection;
+        sign.setLevel(p.level());
+        conn.send(sign.getUpdatePacket());
+        sign.setLevel(null);
+        conn.send(new ClientboundOpenSignEditorPacket((BlockPos)signEditor.getBlockPosition(), true));
+    }
+
+    @Override
+    public void closeSignEditor(Player player, SignEditor signEditor) {
+        Location loc = signEditor.getLocation();
+        signEditor.getPipeline().remove("SignGUI");
+        player.sendBlockChange(loc, loc.getBlock().getBlockData());
+    }
+}

--- a/Mojang1_20_R4/src/main/java/de/rapha149/signgui/version/MojangWrapper1_20_R4.java
+++ b/Mojang1_20_R4/src/main/java/de/rapha149/signgui/version/MojangWrapper1_20_R4.java
@@ -42,8 +42,28 @@ public class MojangWrapper1_20_R4 implements VersionWrapper {
         );
     }
 
+    private static Component[] createLines(String[] textLines, Object[] adventureLines) {
+        Component[] lines = new Component[4];
+        if (adventureLines != null) {
+            for (int i = 0; i < adventureLines.length; i++) {
+                Object line = adventureLines[i];
+                if (line instanceof net.kyori.adventure.text.Component component) {
+                    lines[i] = new AdventureComponent(component);
+                } else if (line == null) {
+                    lines[i] = Component.empty();
+                } else {
+                    throw new IllegalArgumentException("line at index " + i + " is not net.kyori.adventure.text.Component");
+                }
+            }
+        } else {
+            for (int i = 0; i < textLines.length; i++)
+                lines[i] = Component.nullToEmpty(textLines[i]);
+        }
+        return lines;
+    }
+
     @Override
-    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+    public void openSignEditor(Player player, String[] textLines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         ServerPlayer p = ((CraftPlayer) player).getHandle();
         ServerGamePacketListenerImpl conn = p.connection;
 
@@ -54,25 +74,9 @@ public class MojangWrapper1_20_R4 implements VersionWrapper {
         SignText signText = sign.getText(true) // flag = front/back of sign
                 .setColor(net.minecraft.world.item.DyeColor.valueOf(color.toString()));
 
-        Component[] linesToSet = new Component[4];
-        if (adventureLines != null) {
-            for (int i = 0; i < adventureLines.length; i++) {
-                Object line = adventureLines[i];
-                if (line instanceof net.kyori.adventure.text.Component component) {
-                    linesToSet[i] = new AdventureComponent(component);
-                } else if (line == null) {
-                    linesToSet[i] = Component.empty();
-                } else {
-                    throw new IllegalArgumentException("line at index " + i + " is not net.kyori.adventure.text.Component");
-                }
-            }
-        } else {
-            for (int i = 0; i < lines.length; i++)
-                linesToSet[i] = Component.nullToEmpty(lines[i]);
-        }
-
-        for (int i = 0; i < linesToSet.length; i++)
-            signText = signText.setMessage(i, linesToSet[i]);
+        Component[] lines = createLines(textLines, adventureLines);
+        for (int i = 0; i < lines.length; i++)
+            signText = signText.setMessage(i, lines[i]);
         sign.setText(signText, true);
 
         boolean schedule = false;
@@ -132,13 +136,13 @@ public class MojangWrapper1_20_R4 implements VersionWrapper {
     }
 
     @Override
-    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    public void displayNewLines(Player player, SignEditor signEditor, String[] textLines, Object[] adventureLines) {
         SignBlockEntity sign = (SignBlockEntity) signEditor.getSign();
 
         SignText newSignText = sign.getText(true);
-        for (int i = 0; i < lines.length; ++i) {
-            newSignText = newSignText.setMessage(i, Component.nullToEmpty(lines[i]));
-        }
+        Component[] lines = createLines(textLines, adventureLines);
+        for (int i = 0; i < textLines.length; ++i)
+            newSignText = newSignText.setMessage(i, lines[i]);
         sign.setText(newSignText, true);
 
         ServerPlayer p = ((CraftPlayer) player).getHandle();

--- a/Mojang1_21_R1/pom.xml
+++ b/Mojang1_21_R1/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>signgui-parent</artifactId>
+        <version>2.4.0</version>
+        <groupId>de.rapha149.signgui</groupId>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>signgui-1_21_R1-mojang</artifactId>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ca.bkaw</groupId>
+            <artifactId>paper-nms</artifactId>
+            <version>1.21-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.signgui</groupId>
+            <artifactId>signgui-wrapper</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bytecode.space</id>
+            <url>https://repo.bytecode.space/repository/maven-public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>ca.bkaw</groupId>
+                <artifactId>paper-nms-maven-plugin</artifactId>
+                <version>1.4.4</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/Mojang1_21_R1/pom.xml
+++ b/Mojang1_21_R1/pom.xml
@@ -16,6 +16,7 @@
     </properties>
 
     <dependencies>
+        <!-- plugins -> paper-nms -> init (https://github.com/Alvinn8/paper-nms-maven-plugin) -->
         <dependency>
             <groupId>ca.bkaw</groupId>
             <artifactId>paper-nms</artifactId>

--- a/Mojang1_21_R1/src/main/java/de/rapha149/signgui/version/MojangWrapper1_21_R1.java
+++ b/Mojang1_21_R1/src/main/java/de/rapha149/signgui/version/MojangWrapper1_21_R1.java
@@ -1,0 +1,179 @@
+package de.rapha149.signgui.version;
+
+import de.rapha149.signgui.SignEditor;
+import de.rapha149.signgui.SignGUIChannelHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.papermc.paper.adventure.AdventureComponent;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.Connection;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundOpenSignEditorPacket;
+import net.minecraft.network.protocol.game.ServerboundSignUpdatePacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.level.block.entity.SignBlockEntity;
+import net.minecraft.world.level.block.entity.SignText;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+public class MojangWrapper1_21_R1 implements AdventureVersionWrapper {
+
+    @Override
+    public Material getDefaultType() {
+        return Material.OAK_SIGN;
+    }
+
+    @Override
+    public List<Material> getSignTypes() {
+        return Arrays.asList(Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN, Material.JUNGLE_SIGN,
+                Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.CRIMSON_SIGN, Material.WARPED_SIGN,
+                Material.CHERRY_SIGN, Material.MANGROVE_SIGN, Material.BAMBOO_SIGN
+        );
+    }
+
+    private net.kyori.adventure.text.Component[] adventureLines = null;
+
+    @Override
+    public void setAdventureLines(Object[] lines) {
+        var tmp = new net.kyori.adventure.text.Component[4];
+        for (int i = 0; i < lines.length; i++) {
+            var line = lines[i];
+            if (line instanceof net.kyori.adventure.text.Component comp) {
+                tmp[i] = comp;
+            } else if (line == null) {
+                tmp[i] = null;
+            } else {
+                throw new IllegalArgumentException("line at index "+i+" is not net.kyori.adventure.text.Component");
+            }
+        }
+        adventureLines = tmp;
+    }
+
+    private Component[] createLines(String[] textLines){
+        var ret = new Component[4];
+        if (adventureLines != null) {
+            for (int i = 0; i < adventureLines.length; i++) {
+                var comp = adventureLines[i];
+                if (comp == null) {
+                    ret[i] = Component.empty();
+                } else {
+                    ret[i] = new AdventureComponent(comp);
+                }
+            }
+        } else {
+            for (int i = 0; i < textLines.length; i++) {
+                var line = textLines[i];
+                ret[i] = Component.nullToEmpty(line);
+            }
+        }
+        return ret;
+    }
+
+    @Override
+    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+        ServerPlayer p = ((CraftPlayer) player).getHandle();
+        ServerGamePacketListenerImpl conn = p.connection;
+
+        Location loc = signLoc != null ? signLoc : getDefaultLocation(player);
+        BlockPos pos = new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+
+        SignBlockEntity sign = new SignBlockEntity(pos, null);
+        SignText signText = sign.getText(true) // flag = front/back of sign
+                .setColor(net.minecraft.world.item.DyeColor.valueOf(color.toString()));
+        var linesToSet = createLines(lines);
+        for (int i = 0; i < linesToSet.length; i++)
+            signText = signText.setMessage(i, linesToSet[i]);
+        sign.setText(signText, true);
+
+        boolean schedule = false;
+        Connection manager = conn.connection;
+        ChannelPipeline pipeline = manager.channel.pipeline();
+        if (pipeline.names().contains("SignGUI")) {
+            ChannelHandler handler = pipeline.get("SignGUI");
+            if (handler instanceof SignGUIChannelHandler<?> signGUIHandler) {
+                signGUIHandler.close();
+                schedule = signGUIHandler.getBlockPosition().equals(pos);
+            }
+
+            if (pipeline.names().contains("SignGUI"))
+                pipeline.remove("SignGUI");
+        }
+
+        Runnable runnable = () -> {
+            player.sendBlockChange(loc, type.createBlockData());
+            sign.setLevel(p.level());
+            conn.send(sign.getUpdatePacket());
+            sign.setLevel(null);
+            conn.send(new ClientboundOpenSignEditorPacket(pos, true)); // flag = front/back of sign
+
+            SignEditor signEditor = new SignEditor(sign, loc, pos, pipeline);
+            pipeline.addAfter("decoder", "SignGUI", new SignGUIChannelHandler<Packet<?>>() {
+
+                @Override
+                public Object getBlockPosition() {
+                    return pos;
+                }
+
+                @Override
+                public void close() {
+                    closeSignEditor(player, signEditor);
+                }
+
+                @Override
+                protected void decode(ChannelHandlerContext chc, Packet<?> packet, List<Object> out) {
+                    try {
+                        if (packet instanceof ServerboundSignUpdatePacket updateSign) {
+                            if (updateSign.getPos().equals(pos))
+                                onFinish.accept(signEditor, updateSign.getLines());
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+
+                    out.add(packet);
+                }
+            });
+        };
+
+        if (schedule)
+            SCHEDULER.schedule(runnable, 200, TimeUnit.MILLISECONDS);
+        else
+            runnable.run();
+    }
+
+    @Override
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+        SignBlockEntity sign = (SignBlockEntity)signEditor.getSign();
+
+        SignText newSignText = sign.getText(true);
+        for(int i = 0; i < lines.length; ++i) {
+            newSignText = newSignText.setMessage(i, Component.nullToEmpty(lines[i]));
+        }
+        sign.setText(newSignText, true);
+
+        ServerPlayer p = ((CraftPlayer)player).getHandle();
+        ServerGamePacketListenerImpl conn = p.connection;
+        sign.setLevel(p.level());
+        conn.send(sign.getUpdatePacket());
+        sign.setLevel(null);
+        conn.send(new ClientboundOpenSignEditorPacket((BlockPos)signEditor.getBlockPosition(), true));
+    }
+
+    @Override
+    public void closeSignEditor(Player player, SignEditor signEditor) {
+        Location loc = signEditor.getLocation();
+        signEditor.getPipeline().remove("SignGUI");
+        player.sendBlockChange(loc, loc.getBlock().getBlockData());
+    }
+}

--- a/Mojang1_21_R1/src/main/java/de/rapha149/signgui/version/MojangWrapper1_21_R1.java
+++ b/Mojang1_21_R1/src/main/java/de/rapha149/signgui/version/MojangWrapper1_21_R1.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
-public class MojangWrapper1_21_R1 implements AdventureVersionWrapper {
+public class MojangWrapper1_21_R1 implements VersionWrapper {
 
     @Override
     public Material getDefaultType() {
@@ -42,46 +42,8 @@ public class MojangWrapper1_21_R1 implements AdventureVersionWrapper {
         );
     }
 
-    private net.kyori.adventure.text.Component[] adventureLines = null;
-
     @Override
-    public void setAdventureLines(Object[] lines) {
-        var tmp = new net.kyori.adventure.text.Component[4];
-        for (int i = 0; i < lines.length; i++) {
-            var line = lines[i];
-            if (line instanceof net.kyori.adventure.text.Component comp) {
-                tmp[i] = comp;
-            } else if (line == null) {
-                tmp[i] = null;
-            } else {
-                throw new IllegalArgumentException("line at index "+i+" is not net.kyori.adventure.text.Component");
-            }
-        }
-        adventureLines = tmp;
-    }
-
-    private Component[] createLines(String[] textLines){
-        var ret = new Component[4];
-        if (adventureLines != null) {
-            for (int i = 0; i < adventureLines.length; i++) {
-                var comp = adventureLines[i];
-                if (comp == null) {
-                    ret[i] = Component.empty();
-                } else {
-                    ret[i] = new AdventureComponent(comp);
-                }
-            }
-        } else {
-            for (int i = 0; i < textLines.length; i++) {
-                var line = textLines[i];
-                ret[i] = Component.nullToEmpty(line);
-            }
-        }
-        return ret;
-    }
-
-    @Override
-    public void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
         ServerPlayer p = ((CraftPlayer) player).getHandle();
         ServerGamePacketListenerImpl conn = p.connection;
 
@@ -91,7 +53,24 @@ public class MojangWrapper1_21_R1 implements AdventureVersionWrapper {
         SignBlockEntity sign = new SignBlockEntity(pos, null);
         SignText signText = sign.getText(true) // flag = front/back of sign
                 .setColor(net.minecraft.world.item.DyeColor.valueOf(color.toString()));
-        var linesToSet = createLines(lines);
+
+        Component[] linesToSet = new Component[4];
+        if (adventureLines != null) {
+            for (int i = 0; i < adventureLines.length; i++) {
+                Object line = adventureLines[i];
+                if (line instanceof net.kyori.adventure.text.Component component) {
+                    linesToSet[i] = new AdventureComponent(component);
+                } else if (line == null) {
+                    linesToSet[i] = Component.empty();
+                } else {
+                    throw new IllegalArgumentException("line at index " + i + " is not net.kyori.adventure.text.Component");
+                }
+            }
+        } else {
+            for (int i = 0; i < lines.length; i++)
+                linesToSet[i] = Component.nullToEmpty(lines[i]);
+        }
+
         for (int i = 0; i < linesToSet.length; i++)
             signText = signText.setMessage(i, linesToSet[i]);
         sign.setText(signText, true);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SignGUI [![Build](https://github.com/Rapha149/SignGUI/actions/workflows/build.yml/badge.svg)](https://github.com/Rapha149/SignGUI/actions/workflows/build.yml) [![Maven Central](https://img.shields.io/maven-central/v/de.rapha149.signgui/signgui?label=Maven%20Central)](https://central.sonatype.com/artifact/de.rapha149.signgui/signgui) [![Javadoc](https://javadoc.io/badge2/de.rapha149.signgui/signgui/Javadoc.svg)](https://javadoc.io/doc/de.rapha149.signgui/signgui) 
 An api to get input text via a sign in Minecraft.  
-The api supports the Minecraft versions from `1.8` to `1.21`. Also supports adventure text and mojang-mapped plugins from 2.4.0
+The api supports the Minecraft versions from `1.8` to `1.21`.  
+Also supports adventure text and mojang-mapped Paper plugins (1.20.5+).
 
 ## Integration
 
@@ -56,6 +57,7 @@ There are two solution to this problem:
    Wrapper1_20_R4.class.getName()
    ```
    I used the class `Wrapper1_20_R4` in this example which corresponds to the Minecraft version `1.20.5` and `1.20.6`.
+   If you are using a mojang-mapped Paper plugin the class would be `MojangWrapper1_20_R4`.  
    In order to find out which Minecraft version corresponds to which wrapper class you can check out this Github repository of mine: [NMSVersions](https://github.com/Rapha149/NMSVersions?tab=readme-ov-file#versions).  
    ​
 3. Exclude the SignGUI dependency from being affected by the `minimize()` method like this:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SignGUI [![Build](https://github.com/Rapha149/SignGUI/actions/workflows/build.yml/badge.svg)](https://github.com/Rapha149/SignGUI/actions/workflows/build.yml) [![Maven Central](https://img.shields.io/maven-central/v/de.rapha149.signgui/signgui?label=Maven%20Central)](https://central.sonatype.com/artifact/de.rapha149.signgui/signgui) [![Javadoc](https://javadoc.io/badge2/de.rapha149.signgui/signgui/Javadoc.svg)](https://javadoc.io/doc/de.rapha149.signgui/signgui) 
 An api to get input text via a sign in Minecraft.  
-The api supports the Minecraft versions from `1.8` to `1.21`.
+The api supports the Minecraft versions from `1.8` to `1.21`. Also supports adventure text and mojang-mapped plugins from 2.4.0
 
 ## Integration
 
@@ -9,7 +9,7 @@ Maven dependency:
 <dependency>
     <groupId>de.rapha149.signgui</groupId>
     <artifactId>signgui</artifactId>
-    <version>2.3.6</version>
+    <version>2.4.0</version>
 </dependency>
 ```
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,8 +6,8 @@
 
     <parent>
         <artifactId>signgui-parent</artifactId>
+        <version>2.4.0</version>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
     </parent>
 
     <artifactId>signgui</artifactId>
@@ -208,6 +208,18 @@
         <dependency>
             <groupId>de.rapha149.signgui</groupId>
             <artifactId>signgui-1_21_R1</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.signgui</groupId>
+            <artifactId>signgui-1_20_R4-mojang</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.signgui</groupId>
+            <artifactId>signgui-1_21_R1-mojang</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -207,13 +207,13 @@
         </dependency>
         <dependency>
             <groupId>de.rapha149.signgui</groupId>
-            <artifactId>signgui-1_21_R1</artifactId>
+            <artifactId>signgui-1_20_R4-mojang</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.rapha149.signgui</groupId>
-            <artifactId>signgui-1_20_R4-mojang</artifactId>
+            <artifactId>signgui-1_21_R1</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/api/src/main/java/de/rapha149/signgui/SignGUI.java
+++ b/api/src/main/java/de/rapha149/signgui/SignGUI.java
@@ -198,15 +198,18 @@ public class SignGUI {
      * This is called when {@link SignGUIAction#displayNewLines(String...)} is returned as an action after the player has finished editing.
      *
      * @param lines The lines, must be exactly 4.
+     * @param adventureLines The lines using Adventure components (1.20.5+). Must be exactly 4. May be null.
      * @throws java.lang.IllegalArgumentException If lines is null or not exactly 4 lines.
      * @throws SignGUIException                   If an error occurs while setting the lines.
      */
-    void displayNewLines(Player player, SignEditor signEditor, String[] lines) {
+    void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
         Validate.notNull(lines, "The lines cannot be null");
         Validate.isTrue(lines.length == 4, "The lines must have a length of 4");
+        if (adventureLines != null)
+            Validate.isTrue(adventureLines.length == 4, "The adventure lines must null or have a length of 4");
 
         try {
-            WRAPPER.displayNewLines(player, signEditor, lines);
+            WRAPPER.displayNewLines(player, signEditor, lines, adventureLines);
         } catch (Exception e) {
             throw new SignGUIException("Failed to display new lines", e);
         }

--- a/api/src/main/java/de/rapha149/signgui/SignGUIAction.java
+++ b/api/src/main/java/de/rapha149/signgui/SignGUIAction.java
@@ -1,11 +1,9 @@
 package de.rapha149.signgui;
 
-import de.rapha149.signgui.version.VersionWrapper;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Arrays;
@@ -16,15 +14,15 @@ import java.util.Arrays;
 public interface SignGUIAction {
 
     /**
-     * @return The {@link SignGUIActionInfo} instance containing information about this action
+     * @return The {@link de.rapha149.signgui.SignGUIAction.SignGUIActionInfo} instance containing information about this action
      */
     SignGUIActionInfo getInfo();
 
     /**
      * Called to execute the actions after the player finished editing the sign.
      *
-     * @param gui    The {@link SignGUI} instance
-     * @param signEditor The {@link SignEditor} instance containing information relevant to the {@link VersionWrapper}
+     * @param gui    The {@link de.rapha149.signgui.SignGUI} instance
+     * @param signEditor The {@link de.rapha149.signgui.SignEditor} instance containing information relevant to the {@link de.rapha149.signgui.version.VersionWrapper}
      * @param player The player who edited the sign
      */
     void execute(SignGUI gui, SignEditor signEditor, Player player);
@@ -33,8 +31,8 @@ public interface SignGUIAction {
      * Creates a new SignGUIAction that opens the sign gui again with the new lines.
      *
      * @param lines The new lines, may be less then 4
-     * @return The new {@link SignGUIAction} instance
-     * @throws java.lang.IllegalArgumentException If lines is null.
+     * @return The new {@link de.rapha149.signgui.SignGUIAction} instance
+     * @throws IllegalArgumentException If lines is null.
      */
     static SignGUIAction displayNewLines(String... lines) {
         Validate.notNull(lines, "The lines cannot be null");
@@ -50,18 +48,64 @@ public interface SignGUIAction {
 
             @Override
             public void execute(SignGUI gui, SignEditor signEditor, Player player) {
-                gui.displayNewLines(player, signEditor, Arrays.copyOf(lines, 4));
+                gui.displayNewLines(player, signEditor, Arrays.copyOf(lines, 4), null);
+            }
+        };
+    }
+
+    /**
+     * Creates a new SignGUIAction that opens the sign gui again with the new lines using the Adventure component (1.20.5+).
+     * Lines set using this method are only shown when using a mojang-mapped Paper plugin.
+     * If you want to set fallback lines to use when Adventure components cannot be used, use {@link #displayNewAdventureLines(Object[], String[])}.
+     * Please note that if you use this method and the Adventure components cannot be used, the sign will be empty.
+     *
+     * @param adventureLines The new adventure lines, may be less then 4
+     * @return The new {@link de.rapha149.signgui.SignGUIAction} instance
+     * @throws IllegalArgumentException If adventure lines is null.
+     * @see #displayNewAdventureLines(Object[], String[])
+     */
+    static SignGUIAction displayNewAdventureLines(Object... adventureLines) {
+        return displayNewAdventureLines(adventureLines, null);
+    }
+
+    /**
+     * Creates a new SignGUIAction that opens the sign gui again with the new lines using the Adventure component (1.20.5+).
+     * Lines set using this method are only shown when using a mojang-mapped Paper plugin.
+     * Please note that if you use don't submit fallback lines'and the Adventure components cannot be used, the sign will be empty.
+     *
+     * @param adventureLines The new lines, may be less then 4
+     * @param fallbackLines  The fallback lines, may be less then 4. These are used when the Adventure components cannot be used. May be null.
+     * @return The new {@link de.rapha149.signgui.SignGUIAction} instance
+     * @throws IllegalArgumentException If adventure lines is null.
+     * @see #displayNewLines(String...)
+     */
+    static SignGUIAction displayNewAdventureLines(Object[] adventureLines, String[] fallbackLines) {
+        Validate.notNull(adventureLines, "The lines cannot be null");
+
+        return new SignGUIAction() {
+
+            private SignGUIActionInfo info = new SignGUIActionInfo("displayNewLines", true, 1);
+
+            @Override
+            public SignGUIActionInfo getInfo() {
+                return info;
+            }
+
+            @Override
+            public void execute(SignGUI gui, SignEditor signEditor, Player player) {
+                gui.displayNewLines(player, signEditor, fallbackLines != null ? Arrays.copyOf(fallbackLines, 4) : new String[4],
+                        Arrays.copyOf(adventureLines, 4));
             }
         };
     }
 
     /**
      * Creates a new SignGUIAction that opens an inventory.
-     * The inventory is opened synchronously by calling the method {@link org.bukkit.scheduler.BukkitScheduler#runTask(Plugin, Runnable)}
+     * The inventory is opened synchronously by calling the method {@link org.bukkit.scheduler.BukkitScheduler#runTask(org.bukkit.plugin.Plugin, Runnable)}
      *
      * @param plugin    Your {@link org.bukkit.plugin.java.JavaPlugin} instance
      * @param inventory The inventory to open
-     * @return The new {@link SignGUIAction} instance
+     * @return The new {@link de.rapha149.signgui.SignGUIAction} instance
      */
     static SignGUIAction openInventory(JavaPlugin plugin, Inventory inventory) {
         Validate.notNull(plugin, "The plugin cannot be null");
@@ -88,7 +132,7 @@ public interface SignGUIAction {
      * The runnable will be run asynchronously.
      *
      * @param runnable The runnable to run
-     * @return The new {@link SignGUIAction} instance
+     * @return The new {@link de.rapha149.signgui.SignGUIAction} instance
      */
     static SignGUIAction run(Runnable runnable) {
         Validate.notNull(runnable, "The runnable cannot be null");
@@ -114,7 +158,7 @@ public interface SignGUIAction {
      *
      * @param plugin   Your {@link org.bukkit.plugin.java.JavaPlugin} instance
      * @param runnable The runnable to run
-     * @return The new {@link SignGUIAction} instance
+     * @return The new {@link de.rapha149.signgui.SignGUIAction} instance
      */
     static SignGUIAction runSync(JavaPlugin plugin, Runnable runnable) {
         Validate.notNull(plugin, "The plugin cannot be null");
@@ -137,7 +181,7 @@ public interface SignGUIAction {
     }
 
     /**
-     * Describes a {@link SignGUIAction}
+     * Describes a {@link de.rapha149.signgui.SignGUIAction}
      */
     class SignGUIActionInfo {
 

--- a/api/src/main/java/de/rapha149/signgui/SignGUIBuilder.java
+++ b/api/src/main/java/de/rapha149/signgui/SignGUIBuilder.java
@@ -20,6 +20,7 @@ public class SignGUIBuilder {
     private SignGUIFinishHandler handler;
     private boolean callHandlerSynchronously = false;
     private JavaPlugin plugin;
+    private Object[] adventureLines = null;
 
     /**
      * Constructs a new SignGUIBuilder. Use {@link SignGUI#builder()} to get a new instance.
@@ -51,6 +52,34 @@ public class SignGUIBuilder {
     public SignGUIBuilder setLine(int index, String line) {
         Validate.isTrue(index >= 0 && index <= 3, "Index out of range");
         lines[index] = line;
+        return this;
+    }
+
+    /**
+     * Sets the lines that are shown on the sign.
+     *
+     * @param lines The lines, may be less than 4.
+     * @return The {@link SignGUIBuilder} instance
+     * @throws java.lang.IllegalArgumentException If lines is null.
+     */
+    public SignGUIBuilder setAdventureLines(Object... lines) {
+        Validate.notNull(lines, "The lines cannot be null");
+        this.adventureLines = lines;
+        return this;
+    }
+
+    /**
+     * Sets a specific line that is shown on the sign.
+     *
+     * @param index The index of the line.
+     * @param component  Adventure component
+     * @return The {@link SignGUIBuilder} instance
+     * @throws java.lang.IllegalArgumentException If the index is below 0 or above 4.
+     */
+    public SignGUIBuilder setAdventureLine(int index, Object component) {
+        Validate.isTrue(index >= 0 && index <= 3, "Index out of range");
+        if (adventureLines == null) adventureLines = new Object[4];
+        adventureLines[index] = component;
         return this;
     }
 
@@ -125,6 +154,6 @@ public class SignGUIBuilder {
      */
     public SignGUI build() {
         Validate.notNull(handler, "handler must be set");
-        return new SignGUI(lines, type, color, loc, handler, callHandlerSynchronously, plugin);
+        return new SignGUI(lines, type, color, loc, handler, callHandlerSynchronously, plugin, adventureLines);
     }
 }

--- a/api/src/main/java/de/rapha149/signgui/SignGUIBuilder.java
+++ b/api/src/main/java/de/rapha149/signgui/SignGUIBuilder.java
@@ -14,13 +14,13 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class SignGUIBuilder {
 
     private String[] lines = new String[4];
+    private Object[] adventureLines = null;
     private Material type = SignGUI.WRAPPER.getDefaultType();
     private DyeColor color = DyeColor.BLACK;
     private Location loc;
     private SignGUIFinishHandler handler;
     private boolean callHandlerSynchronously = false;
     private JavaPlugin plugin;
-    private Object[] adventureLines = null;
 
     /**
      * Constructs a new SignGUIBuilder. Use {@link SignGUI#builder()} to get a new instance.
@@ -56,7 +56,8 @@ public class SignGUIBuilder {
     }
 
     /**
-     * Sets the lines that are shown on the sign.
+     * Sets the lines that are shown on the sign using an Adventure component.
+     * Lines set using this method are only shown when using a mojang-mapped Paper plugin.
      *
      * @param lines The lines, may be less than 4.
      * @return The {@link SignGUIBuilder} instance
@@ -69,7 +70,8 @@ public class SignGUIBuilder {
     }
 
     /**
-     * Sets a specific line that is shown on the sign.
+     * Sets a specific line that is shown on the sign using an Adventure component.
+     * Lines set using this method are only shown when using a mojang-mapped Paper plugin.
      *
      * @param index The index of the line.
      * @param component  Adventure component
@@ -78,7 +80,8 @@ public class SignGUIBuilder {
      */
     public SignGUIBuilder setAdventureLine(int index, Object component) {
         Validate.isTrue(index >= 0 && index <= 3, "Index out of range");
-        if (adventureLines == null) adventureLines = new Object[4];
+        if (adventureLines == null)
+            adventureLines = new Object[4];
         adventureLines[index] = component;
         return this;
     }
@@ -154,6 +157,6 @@ public class SignGUIBuilder {
      */
     public SignGUI build() {
         Validate.notNull(handler, "handler must be set");
-        return new SignGUI(lines, type, color, loc, handler, callHandlerSynchronously, plugin, adventureLines);
+        return new SignGUI(lines, adventureLines, type, color, loc, handler, callHandlerSynchronously, plugin);
     }
 }

--- a/api/src/main/java/de/rapha149/signgui/SignGUIBuilder.java
+++ b/api/src/main/java/de/rapha149/signgui/SignGUIBuilder.java
@@ -8,6 +8,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.Arrays;
+
 /**
  * Builder for {@link SignGUI}.
  */
@@ -37,7 +39,7 @@ public class SignGUIBuilder {
      */
     public SignGUIBuilder setLines(String... lines) {
         Validate.notNull(lines, "The lines cannot be null");
-        this.lines = lines;
+        this.lines = Arrays.copyOf(lines, 4);
         return this;
     }
 
@@ -56,22 +58,24 @@ public class SignGUIBuilder {
     }
 
     /**
-     * Sets the lines that are shown on the sign using an Adventure component.
+     * Sets the lines that are shown on the sign using an Adventure component (1.20.5+)
      * Lines set using this method are only shown when using a mojang-mapped Paper plugin.
+     * It is recommended to also set fallback lines using {@link #setLines(String...)} as these will be used if the Adventure components cannot be used for some reason.
      *
-     * @param lines The lines, may be less than 4.
+     * @param adventureLines The lines, may be less than 4.
      * @return The {@link SignGUIBuilder} instance
      * @throws java.lang.IllegalArgumentException If lines is null.
      */
-    public SignGUIBuilder setAdventureLines(Object... lines) {
-        Validate.notNull(lines, "The lines cannot be null");
-        this.adventureLines = lines;
+    public SignGUIBuilder setAdventureLines(Object... adventureLines) {
+        Validate.notNull(adventureLines, "The adventure lines cannot be null");
+        this.adventureLines = Arrays.copyOf(adventureLines, 4);
         return this;
     }
 
     /**
-     * Sets a specific line that is shown on the sign using an Adventure component.
+     * Sets a specific line that is shown on the sign using an Adventure component (1.20.5+)
      * Lines set using this method are only shown when using a mojang-mapped Paper plugin.
+     * It is recommended to also set fallback lines using {@link #setLine(int, String)} as these will be used if the Adventure components cannot be used for some reason.
      *
      * @param index The index of the line.
      * @param component  Adventure component

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>de.rapha149.signgui</groupId>
     <artifactId>signgui-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.6</version>
+    <version>2.4.0</version>
 
     <modules>
         <module>api</module>
@@ -37,7 +37,9 @@
         <module>1_20_R2</module>
         <module>1_20_R3</module>
         <module>1_20_R4</module>
+        <module>Mojang1_20_R4</module>
         <module>1_21_R1</module>
+        <module>Mojang1_21_R1</module>
     </modules>
 
     <properties>

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -6,8 +6,8 @@
 
     <parent>
         <artifactId>signgui-parent</artifactId>
-        <version>2.4.0</version>
         <groupId>de.rapha149.signgui</groupId>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>signgui-wrapper</artifactId>

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -6,8 +6,8 @@
 
     <parent>
         <artifactId>signgui-parent</artifactId>
+        <version>2.4.0</version>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.3.6</version>
     </parent>
 
     <artifactId>signgui-wrapper</artifactId>

--- a/wrapper/src/main/java/de/rapha149/signgui/version/AdventureVersionWrapper.java
+++ b/wrapper/src/main/java/de/rapha149/signgui/version/AdventureVersionWrapper.java
@@ -1,0 +1,5 @@
+package de.rapha149.signgui.version;
+
+public interface AdventureVersionWrapper extends VersionWrapper {
+    void setAdventureLines(Object[] lines);
+}

--- a/wrapper/src/main/java/de/rapha149/signgui/version/AdventureVersionWrapper.java
+++ b/wrapper/src/main/java/de/rapha149/signgui/version/AdventureVersionWrapper.java
@@ -1,5 +1,0 @@
-package de.rapha149.signgui.version;
-
-public interface AdventureVersionWrapper extends VersionWrapper {
-    void setAdventureLines(Object[] lines);
-}

--- a/wrapper/src/main/java/de/rapha149/signgui/version/VersionWrapper.java
+++ b/wrapper/src/main/java/de/rapha149/signgui/version/VersionWrapper.java
@@ -38,7 +38,7 @@ public interface VersionWrapper {
      * @param signLoc  The location where the sign should be placed. Can be null for default.
      * @param onFinish The {@link java.util.function.BiConsumer} which is called when the player finished editing the sign.
      */
-    void openSignEditor(Player player, String[] lines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws Exception;
+    void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws Exception;
 
     /**
      * Called when the lines of a sign should be updated.

--- a/wrapper/src/main/java/de/rapha149/signgui/version/VersionWrapper.java
+++ b/wrapper/src/main/java/de/rapha149/signgui/version/VersionWrapper.java
@@ -47,7 +47,7 @@ public interface VersionWrapper {
      * @param signEditor The sign editor.
      * @param lines The new lines.
      */
-    void displayNewLines(Player player, SignEditor signEditor, String[] lines);
+    void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines);
 
     /**
      * Called when the sign editor should be closed.


### PR DESCRIPTION
This PR adds ability to use SignGUI in plugin that doesn't remaps (plugin that use mojang mappings). (Only on paper 1.20.5+).
Also added [adventure](https://docs.advntr.dev/index.html#) support on paper 1.20.5+. To use it there a new methods in builder `setAdventureLines(Object... lines)` and `setAdventureLine(int index, Object component)`.
In minor changes, added connection timeout of 10 seconds when getting online version list.

I think that mojang mappings support is not a little update so i changed version to 2.4.0. Hoping for merge.