### PR TITLE
Add support for 1.21.6 and refactored wrapper to match conventions

### DIFF
--- a/1_10_R1/pom.xml
+++ b/1_10_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_11_R1/pom.xml
+++ b/1_11_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_12_R1/pom.xml
+++ b/1_12_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_13_R1/pom.xml
+++ b/1_13_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_13_R2/pom.xml
+++ b/1_13_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_14_R1/pom.xml
+++ b/1_14_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_15_R1/pom.xml
+++ b/1_15_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_16_R1/pom.xml
+++ b/1_16_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_16_R2/pom.xml
+++ b/1_16_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_16_R3/pom.xml
+++ b/1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_17_R1/pom.xml
+++ b/1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R2/pom.xml
+++ b/1_21_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R2.java
+++ b/1_21_R2/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R2.java
@@ -101,7 +101,7 @@ public class Wrapper1_21_R2 implements VersionWrapper {
 
         Runnable runnable = () -> {
             player.sendBlockChange(loc, type.createBlockData());
-            sign.a(p.cU());
+            sign.a(p.dW());
             conn.b(sign.t());
             sign.a((World) null);
             conn.b(new PacketPlayOutOpenSignEditor(pos, true)); // flag = front/back of sign

--- a/1_21_R3/pom.xml
+++ b/1_21_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R3.java
+++ b/1_21_R3/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R3.java
@@ -152,7 +152,7 @@ public class Wrapper1_21_R3 implements VersionWrapper {
 
         EntityPlayer p = ((CraftPlayer) player).getHandle();
         PlayerConnection conn = p.f;
-        sign.a(p.cU());
+        sign.a(p.dV());
         conn.b(sign.s());
         sign.a((World) null);
         conn.b(new PacketPlayOutOpenSignEditor((BlockPosition) signEditor.getBlockPosition(), true));

--- a/1_21_R4/pom.xml
+++ b/1_21_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R4/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R4.java
+++ b/1_21_R4/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R4.java
@@ -101,7 +101,7 @@ public class Wrapper1_21_R4 implements VersionWrapper {
 
         Runnable runnable = () -> {
             player.sendBlockChange(loc, type.createBlockData());
-            sign.a(p.cU());
+            sign.a(p.dV());
             conn.b(sign.s());
             sign.a((World) null);
             conn.b(new PacketPlayOutOpenSignEditor(pos, true)); // flag = front/back of sign

--- a/1_21_R5/pom.xml
+++ b/1_21_R5/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>signgui-1_21_R1</artifactId>
+    <artifactId>signgui-1_21_R5</artifactId>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <version>1.21.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/1_21_R5/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R5.java
+++ b/1_21_R5/src/main/java/de/rapha149/signgui/version/Wrapper1_21_R5.java
@@ -1,0 +1,167 @@
+package de.rapha149.signgui.version;
+
+import de.rapha149.signgui.SignEditor;
+import de.rapha149.signgui.SignGUIChannelHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import net.minecraft.core.BlockPosition;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.PacketPlayInUpdateSign;
+import net.minecraft.network.protocol.game.PacketPlayOutOpenSignEditor;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.server.network.PlayerConnection;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import net.minecraft.world.item.EnumColor;
+import net.minecraft.world.level.World;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.SignText;
+import net.minecraft.world.level.block.entity.TileEntitySign;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+public class Wrapper1_21_R5 implements VersionWrapper {
+
+    private final Field NETWORK_MANAGER_FIELD;
+
+    {
+        Field networkManagerField = null;
+        for (Field field : ServerCommonPacketListenerImpl.class.getDeclaredFields()) {
+            if (field.getType() == NetworkManager.class) {
+                field.setAccessible(true);
+                networkManagerField = field;
+                break;
+            }
+        }
+
+        NETWORK_MANAGER_FIELD = networkManagerField;
+    }
+
+    @Override
+    public Material getDefaultType() {
+        return Material.OAK_SIGN;
+    }
+
+    @Override
+    public List<Material> getSignTypes() {
+        return Arrays.asList(Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN, Material.JUNGLE_SIGN,
+                Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.CRIMSON_SIGN, Material.WARPED_SIGN,
+                Material.CHERRY_SIGN, Material.MANGROVE_SIGN, Material.BAMBOO_SIGN, Material.PALE_OAK_SIGN
+        );
+    }
+
+    @Override
+    public void openSignEditor(Player player, String[] lines, Object[] adventureLines, Material type, DyeColor color, boolean glow, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) throws IllegalAccessException {
+        EntityPlayer p = ((CraftPlayer) player).getHandle();
+        PlayerConnection conn = p.g;
+
+        if (NETWORK_MANAGER_FIELD == null)
+            throw new IllegalStateException("Unable to find NetworkManager field in PlayerConnection class.");
+        if (!NETWORK_MANAGER_FIELD.canAccess(conn)) {
+            NETWORK_MANAGER_FIELD.setAccessible(true);
+            if (!NETWORK_MANAGER_FIELD.canAccess(conn))
+                throw new IllegalStateException("Unable to access NetworkManager field in PlayerConnection class.");
+        }
+
+        Location loc = signLoc != null ? signLoc : getDefaultLocation(player);
+        BlockPosition pos = new BlockPosition(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+
+        TileEntitySign sign = new TileEntitySign(pos, Blocks.cP.m());
+        SignText signText = sign.a(true) // flag = front/back of sign
+                .a(EnumColor.valueOf(color.toString()))
+                .a(glow);
+        for (int i = 0; i < lines.length; i++)
+            signText = signText.a(i, IChatBaseComponent.a(lines[i]));
+        sign.a(signText, true);
+
+        boolean schedule = false;
+        NetworkManager manager = (NetworkManager) NETWORK_MANAGER_FIELD.get(conn);
+        ChannelPipeline pipeline = manager.n.pipeline();
+        if (pipeline.names().contains("SignGUI")) {
+            ChannelHandler handler = pipeline.get("SignGUI");
+            if (handler instanceof SignGUIChannelHandler<?> signGUIHandler) {
+                signGUIHandler.close();
+                schedule = signGUIHandler.getBlockPosition().equals(pos);
+            }
+
+            if (pipeline.names().contains("SignGUI"))
+                pipeline.remove("SignGUI");
+        }
+
+        Runnable runnable = () -> {
+            player.sendBlockChange(loc, type.createBlockData());
+            sign.a(p.ai());
+            conn.b(sign.u());
+            sign.a((World) null);
+            conn.b(new PacketPlayOutOpenSignEditor(pos, true)); // flag = front/back of sign
+
+            SignEditor signEditor = new SignEditor(sign, loc, pos, pipeline);
+            pipeline.addAfter("decoder", "SignGUI", new SignGUIChannelHandler<Packet<?>>() {
+
+                @Override
+                public Object getBlockPosition() {
+                    return pos;
+                }
+
+                @Override
+                public void close() {
+                    closeSignEditor(player, signEditor);
+                }
+
+                @Override
+                protected void decode(ChannelHandlerContext chc, Packet<?> packet, List<Object> out) {
+                    try {
+                        if (packet instanceof PacketPlayInUpdateSign updateSign) {
+                            if (updateSign.b().equals(pos))
+                                onFinish.accept(signEditor, updateSign.f());
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+
+                    out.add(packet);
+                }
+            });
+        };
+
+        if (schedule)
+            SCHEDULER.schedule(runnable, 200, TimeUnit.MILLISECONDS);
+        else
+            runnable.run();
+    }
+
+    @Override
+    public void displayNewLines(Player player, SignEditor signEditor, String[] lines, Object[] adventureLines) {
+        TileEntitySign sign = (TileEntitySign) signEditor.getSign();
+
+        SignText newSignText = sign.a(true);
+        for (int i = 0; i < lines.length; i++)
+            newSignText = newSignText.a(i, IChatBaseComponent.a(lines[i]));
+        sign.a(newSignText, true);
+
+        EntityPlayer p = ((CraftPlayer) player).getHandle();
+        PlayerConnection conn = p.g;
+        sign.a(p.ai());
+        conn.b(sign.u());
+        sign.a((World) null);
+        conn.b(new PacketPlayOutOpenSignEditor((BlockPosition) signEditor.getBlockPosition(), true));
+    }
+
+    @Override
+    public void closeSignEditor(Player player, SignEditor signEditor) {
+        Location loc = signEditor.getLocation();
+        signEditor.getPipeline().remove("SignGUI");
+        player.sendBlockChange(loc, loc.getBlock().getBlockData());
+    }
+}

--- a/1_8_R1/pom.xml
+++ b/1_8_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_8_R2/pom.xml
+++ b/1_8_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_8_R3/pom.xml
+++ b/1_8_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_9_R1/pom.xml
+++ b/1_9_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_9_R2/pom.xml
+++ b/1_9_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Mojang1_20_R4/pom.xml
+++ b/Mojang1_20_R4/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>signgui-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
         <groupId>de.rapha149.signgui</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/Mojang1_21_R1/pom.xml
+++ b/Mojang1_21_R1/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>signgui-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
         <groupId>de.rapha149.signgui</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/Mojang1_21_R2/pom.xml
+++ b/Mojang1_21_R2/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>signgui-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
         <groupId>de.rapha149.signgui</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/Mojang1_21_R3/pom.xml
+++ b/Mojang1_21_R3/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>signgui-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
         <groupId>de.rapha149.signgui</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/Mojang1_21_R4/pom.xml
+++ b/Mojang1_21_R4/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>signgui-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
         <groupId>de.rapha149.signgui</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/Mojang1_21_R5/pom.xml
+++ b/Mojang1_21_R5/pom.xml
@@ -4,22 +4,23 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>signgui-parent</artifactId>
-        <groupId>de.rapha149.signgui</groupId>
         <version>2.5.3</version>
+        <groupId>de.rapha149.signgui</groupId>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>signgui-1_21_R1</artifactId>
+    <artifactId>signgui-1_21_R5-mojang</artifactId>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>
+        <!-- plugins -> paper-nms -> init (https://github.com/Alvinn8/paper-nms-maven-plugin) -->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.21.1-R0.1-SNAPSHOT</version>
+            <groupId>ca.bkaw</groupId>
+            <artifactId>paper-nms</artifactId>
+            <version>1.21.6-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -29,6 +30,13 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>bytecode.space</id>
+            <url>https://repo.bytecode.space/repository/maven-public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <build>
         <plugins>
@@ -40,6 +48,11 @@
                     <source>21</source>
                     <target>21</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>ca.bkaw</groupId>
+                <artifactId>paper-nms-maven-plugin</artifactId>
+                <version>1.4.7</version>
             </plugin>
         </plugins>
     </build>

--- a/Mojang1_21_R5/src/main/java/de/rapha149/signgui/version/MojangWrapper1_21_R5.java
+++ b/Mojang1_21_R5/src/main/java/de/rapha149/signgui/version/MojangWrapper1_21_R5.java
@@ -1,0 +1,164 @@
+package de.rapha149.signgui.version;
+
+import de.rapha149.signgui.SignEditor;
+import de.rapha149.signgui.SignGUIChannelHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.papermc.paper.adventure.AdventureComponent;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.Connection;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundOpenSignEditorPacket;
+import net.minecraft.network.protocol.game.ServerboundSignUpdatePacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.SignBlockEntity;
+import net.minecraft.world.level.block.entity.SignText;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+public class MojangWrapper1_21_R5 implements VersionWrapper {
+
+    @Override
+    public Material getDefaultType() {
+        return Material.OAK_SIGN;
+    }
+
+    @Override
+    public List<Material> getSignTypes() {
+        return Arrays.asList(Material.OAK_SIGN, Material.BIRCH_SIGN, Material.SPRUCE_SIGN, Material.JUNGLE_SIGN,
+                Material.ACACIA_SIGN, Material.DARK_OAK_SIGN, Material.CRIMSON_SIGN, Material.WARPED_SIGN,
+                Material.CHERRY_SIGN, Material.MANGROVE_SIGN, Material.BAMBOO_SIGN, Material.PALE_OAK_SIGN
+        );
+    }
+
+    private static Component[] createLines(String[] textLines, Object[] adventureLines) {
+        Component[] lines = new Component[4];
+        if (adventureLines != null) {
+            for (int i = 0; i < adventureLines.length; i++) {
+                Object line = adventureLines[i];
+                if (line instanceof net.kyori.adventure.text.Component component) {
+                    lines[i] = new AdventureComponent(component);
+                } else if (line == null) {
+                    lines[i] = Component.empty();
+                } else {
+                    throw new IllegalArgumentException("line at index " + i + " is not net.kyori.adventure.text.Component");
+                }
+            }
+        } else {
+            for (int i = 0; i < textLines.length; i++)
+                lines[i] = Component.nullToEmpty(textLines[i]);
+        }
+        return lines;
+    }
+
+    @Override
+    public void openSignEditor(Player player, String[] textLines, Object[] adventureLines, Material type, DyeColor color, boolean glow, Location signLoc, BiConsumer<SignEditor, String[]> onFinish) {
+        ServerPlayer p = ((CraftPlayer) player).getHandle();
+        ServerGamePacketListenerImpl conn = p.connection;
+
+        Location loc = signLoc != null ? signLoc : getDefaultLocation(player);
+        BlockPos pos = new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+
+        SignBlockEntity sign = new SignBlockEntity(pos, Blocks.OAK_SIGN.defaultBlockState());
+        SignText signText = sign.getText(true) // flag = front/back of sign
+                .setColor(net.minecraft.world.item.DyeColor.valueOf(color.toString()))
+                .setHasGlowingText(glow);
+
+        Component[] lines = createLines(textLines, adventureLines);
+        for (int i = 0; i < lines.length; i++)
+            signText = signText.setMessage(i, lines[i]);
+        sign.setText(signText, true);
+
+        boolean schedule = false;
+        Connection manager = conn.connection;
+        ChannelPipeline pipeline = manager.channel.pipeline();
+        if (pipeline.names().contains("SignGUI")) {
+            ChannelHandler handler = pipeline.get("SignGUI");
+            if (handler instanceof SignGUIChannelHandler<?> signGUIHandler) {
+                signGUIHandler.close();
+                schedule = signGUIHandler.getBlockPosition().equals(pos);
+            }
+
+            if (pipeline.names().contains("SignGUI"))
+                pipeline.remove("SignGUI");
+        }
+
+        Runnable runnable = () -> {
+            player.sendBlockChange(loc, type.createBlockData());
+            sign.setLevel(p.level());
+            conn.send(sign.getUpdatePacket());
+            sign.setLevel(null);
+            conn.send(new ClientboundOpenSignEditorPacket(pos, true)); // flag = front/back of sign
+
+            SignEditor signEditor = new SignEditor(sign, loc, pos, pipeline);
+            pipeline.addAfter("decoder", "SignGUI", new SignGUIChannelHandler<Packet<?>>() {
+
+                @Override
+                public Object getBlockPosition() {
+                    return pos;
+                }
+
+                @Override
+                public void close() {
+                    closeSignEditor(player, signEditor);
+                }
+
+                @Override
+                protected void decode(ChannelHandlerContext chc, Packet<?> packet, List<Object> out) {
+                    try {
+                        if (packet instanceof ServerboundSignUpdatePacket updateSign) {
+                            if (updateSign.getPos().equals(pos))
+                                onFinish.accept(signEditor, updateSign.getLines());
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+
+                    out.add(packet);
+                }
+            });
+        };
+
+        if (schedule)
+            SCHEDULER.schedule(runnable, 200, TimeUnit.MILLISECONDS);
+        else
+            runnable.run();
+    }
+
+    @Override
+    public void displayNewLines(Player player, SignEditor signEditor, String[] textLines, Object[] adventureLines) {
+        SignBlockEntity sign = (SignBlockEntity)signEditor.getSign();
+
+        SignText newSignText = sign.getText(true);
+        Component[] lines = createLines(textLines, adventureLines);
+        for(int i = 0; i < textLines.length; ++i)
+            newSignText = newSignText.setMessage(i, lines[i]);
+        sign.setText(newSignText, true);
+
+        ServerPlayer p = ((CraftPlayer)player).getHandle();
+        ServerGamePacketListenerImpl conn = p.connection;
+        sign.setLevel(p.level());
+        conn.send(sign.getUpdatePacket());
+        sign.setLevel(null);
+        conn.send(new ClientboundOpenSignEditorPacket((BlockPos)signEditor.getBlockPosition(), true));
+    }
+
+    @Override
+    public void closeSignEditor(Player player, SignEditor signEditor) {
+        Location loc = signEditor.getLocation();
+        signEditor.getPipeline().remove("SignGUI");
+        player.sendBlockChange(loc, loc.getBlock().getBlockData());
+    }
+}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <artifactId>signgui-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
         <groupId>de.rapha149.signgui</groupId>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>de.rapha149.signgui</groupId>
     <artifactId>signgui-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.5.2</version>
+    <version>2.5.3</version>
 
     <modules>
         <module>api</module>
@@ -46,6 +46,8 @@
         <module>Mojang1_21_R3</module>
         <module>1_21_R4</module>
         <module>Mojang1_21_R4</module>
+        <module>1_21_R5</module>
+        <module>Mojang1_21_R5</module>
     </modules>
 
     <properties>

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>signgui-parent</artifactId>
         <groupId>de.rapha149.signgui</groupId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
     </parent>
 
     <artifactId>signgui-wrapper</artifactId>


### PR DESCRIPTION
PR to add support for `1.21.6` servers.

### Changes
- Added new wrappers for `1_21_R5` and `Mojang1_21_R5`
- Bumped version to `2.5.3`

### Refactored code
I've refactored the World accessor for `1_21_R2-R4` to match the previous wrappers.
- 1_21_R2
  ```diff
  - sign.a(p.cU());
  + sign.a(p.dW());
  ```
- 1_21_R3
  ```diff
  - sign.a(p.cU());
  + sign.a(p.dV());
  ```
- 1_21_R4
  ```diff
  - sign.a(p.cU());
  + sign.a(p.dV());
  ```
  
These now references World accessors with the following "signature":
```java
public World dW() {
  return this.s;
}
```
Instead of 
```java
public World cU() {
  return this.dW();
}
```

### Testing
- JRE/JDK: Temurin 21.0.7+6
- Server: paper-1.21.6-26
- Successfully built and tested with an upcoming [CommandPrompter](https://github.com/CyR1en/CommandPrompter) update.

_delegating `README.md` to maintainer_