### PR TITLE
Add support for Folia servers with scheduler adapter implementation

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -57,6 +57,12 @@
         </dependency>
         <dependency>
             <groupId>de.rapha149.signgui</groupId>
+            <artifactId>signgui-scheduler</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.signgui</groupId>
             <artifactId>signgui-1_8_R1</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>

--- a/api/src/main/java/de/rapha149/signgui/SignGUI.java
+++ b/api/src/main/java/de/rapha149/signgui/SignGUI.java
@@ -3,9 +3,9 @@ package de.rapha149.signgui;
 import de.rapha149.signgui.SignGUIAction.SignGUIActionInfo;
 import de.rapha149.signgui.exception.SignGUIException;
 import de.rapha149.signgui.exception.SignGUIVersionException;
+import de.rapha149.signgui.scheduler.SchedulerAdapterFactory;
 import de.rapha149.signgui.version.VersionMatcher;
 import org.apache.commons.lang.Validate;
-import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -108,7 +108,7 @@ public class SignGUI {
                 };
 
                 if (callHandlerSynchronously)
-                    Bukkit.getScheduler().runTask(plugin, runnable);
+                    SchedulerAdapterFactory.getScheduler().runAtEntity(plugin, player, runnable, null);
                 else
                     runnable.run();
             });

--- a/api/src/main/java/de/rapha149/signgui/SignGUIAction.java
+++ b/api/src/main/java/de/rapha149/signgui/SignGUIAction.java
@@ -1,5 +1,6 @@
 package de.rapha149.signgui;
 
+import de.rapha149.signgui.scheduler.SchedulerAdapterFactory;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -122,7 +123,7 @@ public interface SignGUIAction {
 
             @Override
             public void execute(SignGUI gui, SignEditor signEditor, Player player) {
-                Bukkit.getScheduler().runTask(plugin, () -> player.openInventory(inventory));
+                SchedulerAdapterFactory.getScheduler().runAtEntity(plugin, player, () -> player.openInventory(inventory), null);
             }
         };
     }
@@ -175,7 +176,7 @@ public interface SignGUIAction {
 
             @Override
             public void execute(SignGUI gui, SignEditor signEditor, Player player) {
-                Bukkit.getScheduler().runTask(plugin, runnable);
+                SchedulerAdapterFactory.getScheduler().runAtEntity(plugin, player, runnable, null);
             }
         };
     }

--- a/api/src/main/java/de/rapha149/signgui/SignGUIBuilder.java
+++ b/api/src/main/java/de/rapha149/signgui/SignGUIBuilder.java
@@ -6,7 +6,6 @@ import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Arrays;
@@ -168,7 +167,9 @@ public class SignGUIBuilder {
     }
 
     /**
-     * If called the handler will be called synchronously by calling the method {@link org.bukkit.scheduler.BukkitScheduler#runTask(Plugin, Runnable)}
+     * If called the handler will be called synchronously on the player's thread.
+     * On Bukkit/Paper servers this runs on the main thread.
+     * On Folia servers this runs on the entity's region thread.
      *
      * @param plugin Your {@link org.bukkit.plugin.java.JavaPlugin} instance.
      * @return The {@link SignGUIBuilder} instance

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <modules>
         <module>api</module>
         <module>wrapper</module>
+        <module>scheduler</module>
         <module>1_8_R1</module>
         <module>1_8_R2</module>
         <module>1_8_R3</module>

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>signgui-parent</artifactId>
+        <groupId>de.rapha149.signgui</groupId>
+        <version>2.5.4</version>
+    </parent>
+
+    <artifactId>signgui-scheduler</artifactId>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>dev.folia</groupId>
+            <artifactId>folia-api</artifactId>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/scheduler/src/main/java/de/rapha149/signgui/scheduler/BukkitSchedulerAdapter.java
+++ b/scheduler/src/main/java/de/rapha149/signgui/scheduler/BukkitSchedulerAdapter.java
@@ -1,0 +1,66 @@
+package de.rapha149.signgui.scheduler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Scheduler adapter implementation for Bukkit/Paper/Spigot servers.
+ * All tasks run on the main server thread except for async tasks.
+ */
+public class BukkitSchedulerAdapter implements SchedulerAdapter {
+
+    @Override
+    public void runNextTick(Plugin plugin, Runnable runnable) {
+        Bukkit.getScheduler().runTask(plugin, runnable);
+    }
+
+    @Override
+    public void runNextTick(Plugin plugin, Runnable runnable, long delayTicks) {
+        Bukkit.getScheduler().runTaskLater(plugin, runnable, delayTicks);
+    }
+
+    @Override
+    public void runAsync(Plugin plugin, Runnable runnable) {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, runnable);
+    }
+
+    @Override
+    public void runAsync(Plugin plugin, Runnable runnable, long delayTicks) {
+        Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, runnable, delayTicks);
+    }
+
+    @Override
+    public void runAtEntity(Plugin plugin, Entity entity, Runnable runnable, @Nullable Runnable retired) {
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            if (entity.isValid()) {
+                runnable.run();
+            } else if (retired != null) {
+                retired.run();
+            }
+        });
+    }
+
+    @Override
+    public void runAtEntity(Plugin plugin, Entity entity, Runnable runnable, @Nullable Runnable retired, long delayTicks) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (entity.isValid()) {
+                runnable.run();
+            } else if (retired != null) {
+                retired.run();
+            }
+        }, delayTicks);
+    }
+
+    @Override
+    public void runAtLocation(Plugin plugin, Location location, Runnable runnable) {
+        Bukkit.getScheduler().runTask(plugin, runnable);
+    }
+
+    @Override
+    public void runAtLocation(Plugin plugin, Location location, Runnable runnable, long delayTicks) {
+        Bukkit.getScheduler().runTaskLater(plugin, runnable, delayTicks);
+    }
+}

--- a/scheduler/src/main/java/de/rapha149/signgui/scheduler/FoliaSchedulerAdapter.java
+++ b/scheduler/src/main/java/de/rapha149/signgui/scheduler/FoliaSchedulerAdapter.java
@@ -1,0 +1,53 @@
+package de.rapha149.signgui.scheduler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Scheduler adapter implementation for Folia servers.
+ * Tasks are scheduled on the appropriate region threads.
+ */
+public class FoliaSchedulerAdapter implements SchedulerAdapter {
+
+    @Override
+    public void runNextTick(Plugin plugin, Runnable runnable) {
+        Bukkit.getGlobalRegionScheduler().run(plugin, task -> runnable.run());
+    }
+
+    @Override
+    public void runNextTick(Plugin plugin, Runnable runnable, long delayTicks) {
+        Bukkit.getGlobalRegionScheduler().runDelayed(plugin, task -> runnable.run(), delayTicks);
+    }
+
+    @Override
+    public void runAsync(Plugin plugin, Runnable runnable) {
+        Bukkit.getAsyncScheduler().runNow(plugin, task -> runnable.run());
+    }
+
+    @Override
+    public void runAsync(Plugin plugin, Runnable runnable, long delayTicks) {
+        Bukkit.getAsyncScheduler().runDelayed(plugin, task -> runnable.run(), delayTicks * 50, java.util.concurrent.TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void runAtEntity(Plugin plugin, Entity entity, Runnable runnable, Runnable retired) {
+        entity.getScheduler().run(plugin, task -> runnable.run(), retired);
+    }
+
+    @Override
+    public void runAtEntity(Plugin plugin, Entity entity, Runnable runnable, Runnable retired, long delayTicks) {
+        entity.getScheduler().runDelayed(plugin, task -> runnable.run(), retired, delayTicks);
+    }
+
+    @Override
+    public void runAtLocation(Plugin plugin, Location location, Runnable runnable) {
+        Bukkit.getRegionScheduler().run(plugin, location, task -> runnable.run());
+    }
+
+    @Override
+    public void runAtLocation(Plugin plugin, Location location, Runnable runnable, long delayTicks) {
+        Bukkit.getRegionScheduler().runDelayed(plugin, location, task -> runnable.run(), delayTicks);
+    }
+}

--- a/scheduler/src/main/java/de/rapha149/signgui/scheduler/SchedulerAdapter.java
+++ b/scheduler/src/main/java/de/rapha149/signgui/scheduler/SchedulerAdapter.java
@@ -1,0 +1,95 @@
+package de.rapha149.signgui.scheduler;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Adapter interface for scheduling tasks across different server implementations.
+ * Supports both Bukkit/Paper and Folia schedulers.
+ */
+public interface SchedulerAdapter {
+
+    /**
+     * Runs a task on the next server tick (main thread for Bukkit, global region for Folia).
+     *
+     * @param plugin   the plugin owning this task
+     * @param runnable the task to execute
+     */
+    void runNextTick(Plugin plugin, Runnable runnable);
+
+    /**
+     * Runs a task after a delay (main thread for Bukkit, global region for Folia).
+     *
+     * @param plugin   the plugin owning this task
+     * @param runnable the task to execute
+     * @param delayTicks the delay in ticks before execution
+     */
+    void runNextTick(Plugin plugin, Runnable runnable, long delayTicks);
+
+    /**
+     * Runs a task asynchronously.
+     *
+     * @param plugin   the plugin owning this task
+     * @param runnable the task to execute
+     */
+    void runAsync(Plugin plugin, Runnable runnable);
+
+    /**
+     * Runs a task asynchronously after a delay.
+     *
+     * @param plugin   the plugin owning this task
+     * @param runnable the task to execute
+     * @param delayTicks the delay in ticks before execution
+     */
+    void runAsync(Plugin plugin, Runnable runnable, long delayTicks);
+
+    /**
+     * Runs a task on the thread that owns the given entity.
+     * On Bukkit, this runs on the main thread.
+     * On Folia, this runs on the entity's region thread.
+     *
+     * @param plugin   the plugin owning this task
+     * @param entity   the entity to run the task for
+     * @param runnable the task to execute
+     * @param retired  called if the entity is removed before the task executes (may be null)
+     */
+    void runAtEntity(Plugin plugin, Entity entity, Runnable runnable, @Nullable Runnable retired);
+
+    /**
+     * Runs a task on the thread that owns the given entity after a delay.
+     * On Bukkit, this runs on the main thread.
+     * On Folia, this runs on the entity's region thread.
+     *
+     * @param plugin   the plugin owning this task
+     * @param entity   the entity to run the task for
+     * @param runnable the task to execute
+     * @param retired  called if the entity is removed before the task executes (may be null)
+     * @param delayTicks the delay in ticks before execution
+     */
+    void runAtEntity(Plugin plugin, Entity entity, Runnable runnable, @Nullable Runnable retired, long delayTicks);
+
+    /**
+     * Runs a task on the thread that owns the given location.
+     * On Bukkit, this runs on the main thread.
+     * On Folia, this runs on the region thread that owns the location.
+     *
+     * @param plugin   the plugin owning this task
+     * @param location the location to run the task at
+     * @param runnable the task to execute
+     */
+    void runAtLocation(Plugin plugin, Location location, Runnable runnable);
+
+    /**
+     * Runs a task on the thread that owns the given location after a delay.
+     * On Bukkit, this runs on the main thread.
+     * On Folia, this runs on the region thread that owns the location.
+     *
+     * @param plugin   the plugin owning this task
+     * @param location the location to run the task at
+     * @param runnable the task to execute
+     * @param delayTicks the delay in ticks before execution
+     */
+    void runAtLocation(Plugin plugin, Location location, Runnable runnable, long delayTicks);
+}

--- a/scheduler/src/main/java/de/rapha149/signgui/scheduler/SchedulerAdapterFactory.java
+++ b/scheduler/src/main/java/de/rapha149/signgui/scheduler/SchedulerAdapterFactory.java
@@ -1,0 +1,57 @@
+package de.rapha149.signgui.scheduler;
+
+/**
+ * Factory class for creating the appropriate scheduler adapter based on server type.
+ * Automatically detects whether the server is running Folia or Bukkit/Paper.
+ */
+public final class SchedulerAdapterFactory {
+
+    private static final boolean IS_FOLIA;
+    private static volatile SchedulerAdapter instance;
+
+    static {
+        IS_FOLIA = detectFolia();
+    }
+
+    private SchedulerAdapterFactory() {
+        // Utility class
+    }
+
+    /**
+     * Detects if the server is running Folia by checking for Folia-specific classes.
+     */
+    private static boolean detectFolia() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns whether the server is running Folia.
+     *
+     * @return true if running on Folia, false otherwise
+     */
+    public static boolean isFolia() {
+        return IS_FOLIA;
+    }
+
+    /**
+     * Gets the singleton scheduler adapter instance.
+     * Creates the appropriate adapter based on the detected server type.
+     *
+     * @return the scheduler adapter instance
+     */
+    public static SchedulerAdapter getScheduler() {
+        if (instance == null) {
+            synchronized (SchedulerAdapterFactory.class) {
+                if (instance == null) {
+                    instance = IS_FOLIA ? new FoliaSchedulerAdapter() : new BukkitSchedulerAdapter();
+                }
+            }
+        }
+        return instance;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new scheduler abstraction layer to support both Bukkit/Paper and Folia servers seamlessly.

A new scheduler module was added, providing a SchedulerAdapter interface with separate implementations for Bukkit and Folia, selected automatically via a factory. The API now uses this adapter instead of calling the Bukkit scheduler directly, improving flexibility and future compatibility.

Additionally, synchronous handlers are now documented to run on the correct thread for the player’s region, ensuring proper behavior under Folia’s threading model.