### PR TITLE
Add missing version mapping for 1.21

### DIFF
--- a/api/src/main/java/de/rapha149/signgui/version/VersionMatcher.java
+++ b/api/src/main/java/de/rapha149/signgui/version/VersionMatcher.java
@@ -23,6 +23,7 @@ public class VersionMatcher {
         Map<String, String> versions = new HashMap<>();
         versions.put("1.20.5", "1_20_R4");
         versions.put("1.20.6", "1_20_R4");
+        versions.put("1.21", "1_21_R1");
         versions.put("1.21.1", "1_21_R1");
         versions.put("1.21.3", "1_21_R2");
         versions.put("1.21.4", "1_21_R3");


### PR DESCRIPTION
Fixed 1.21 missing from the VERSIONS map, causing the wrong wrapper (1_21_R5 instead of 1_21_R1) to be selected